### PR TITLE
Add documentation on basic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ example.drupalproject.com \
 # Using the container name of the web frontend.
 sudo docker exec -it dockerdrupalprojectexample_drupalexampleweb_1 su - ubuntu
 ```
+
+# Configuration
+
+## Project sources path
+
+This example make the assumption that the sources of your Drupal project are installed under ` ~/develop/projects/drupal-example`. Consider to change this value when you copy the [docker-compose.yml.dist](https://github.com/andrewholgate/docker-drupal-project-example/blob/master/docker-compose.yml.dist#L9)


### PR DESCRIPTION
Make evidence that the example consider as base project the `~/develop/projects/drupal-example` path
